### PR TITLE
Fix: DOM Clobbering Gadget found in rollup bundled scripts that leads to XSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -766,9 +766,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.12.1.tgz",
-      "integrity": "sha512-t9elERrz2i4UU9z7AwISj3CQcXP39cWxgRWLdf4Tm6aKm1eYrqHIgjzXBgb67GNY1sZckTFFi0oMozh3/S++Ig==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -1401,9 +1401,9 @@
       }
     },
     "rollup": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.12.1.tgz",
-      "integrity": "sha512-t9elERrz2i4UU9z7AwISj3CQcXP39cWxgRWLdf4Tm6aKm1eYrqHIgjzXBgb67GNY1sZckTFFi0oMozh3/S++Ig==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"


### PR DESCRIPTION
We discovered a DOM Clobbering vulnerability in rollup when bundling scripts that use `import.meta.url` or with plugins that emit and reference asset files from code in `cjs/umd/iife format`. The DOM Clobbering gadget can lead to cross-site scripting (XSS) in web pages where scriptless attacker-controlled HTML elements (e.g., an img tag with an unsanitized `name` attribute) are present.

[CWE-79](https://cwe.mitre.org/data/definitions/79.html)
CVE-2024-47068
